### PR TITLE
Feature enhancements to add group and ability to change run options.

### DIFF
--- a/luda/bootstrap/init.sh
+++ b/luda/bootstrap/init.sh
@@ -7,8 +7,14 @@
 USER_ID=${HOST_USER_ID:-9001}
 USER_NAME=${HOST_USER:-user}
 
+GRP_ID=${HOST_GROUP_ID:-1001}
+GRP_NAME=${HOST_GROUP:-nvidia}
+
 echo "Starting with UID : $USER_ID"
-useradd --shell /bin/bash -u $USER_ID -o -c "" --create-home -G sudo $USER_NAME > /dev/null 2>&1
+echo "Starting with GID : $GRP_ID"
+addgroup --gid ${GRP_ID} ${GRP_NAME}
+useradd --shell /bin/bash -u $USER_ID --gid $GRP_ID -o -c "" --create-home \
+  -G sudo,$GRP_NAME $USER_NAME > /dev/null 2>&1
 export HOME=/home/$USER_NAME
 
 if [ -n "$DEVTOOLS" ]; then
@@ -22,3 +28,4 @@ if [ ${#@} -eq 0 ]; then
 else
     exec /bootstrap/su-exec $USER_NAME "$@"
 fi
+


### PR DESCRIPTION
Automatically add user's group into the container.
Ability to change options for docker's run command. Previously it was hard-coded to be "run --rm -ti", now one can change the "--rm -ti" part to whatever one desires such as "-d -t" for a daemonized case. The default is still "--rm -ti".
