### PR TITLE
Added New Features Needed To Run OpenGL With Luda

### DIFF
--- a/luda/cli.py
+++ b/luda/cli.py
@@ -43,10 +43,10 @@ class DockerVolumeType(click.ParamType):
     ignore_unknown_options=True,
 ))
 @click.option("--work", type=PathType, default=os.getcwd(),
-              help="Specifies the work directory to use")
+              help="Specifies the work directory to use. This is mounted to /work in the container")
 
 @click.option('--no_work_dir', is_flag=True,
-              help="Prevents binding any volume to the containers /word directory. " + \
+              help="Prevents binding any volume to the containers /work directory. " + \
                    "This is necessary if the container already has a /work directory")
 
 @click.option("-v", "--volume", type=DockerVolumeType(), multiple=True,
@@ -63,7 +63,7 @@ class DockerVolumeType(click.ParamType):
                    " container")
 
 @click.option('-d', '--docker_run_args', nargs=1, type=click.UNPROCESSED, default='--rm -ti',
-              help="The run arguments for docker appended in the begining. Make sure to quote " + \
+              help="The run arguments for docker appended before the image name. Make sure to quote " + \
                    "the arguments, i.e. '-d -t'.")
 
 @click.argument('docker_args', nargs=-1, type=click.UNPROCESSED)

--- a/luda/cli.py
+++ b/luda/cli.py
@@ -109,7 +109,6 @@ def main(docker_args, display, docker, dev, no_work_dir, docker_run_args=None, w
         curr_cmd = parse_tuple(curr_cmd)
 
         docker_args += (curr_cmd,)
-        click.echo(docker_args)
 
     cmd = " ".join(nvargs) + " "
     cmd += bootstrap_str + " "

--- a/luda/luda.py
+++ b/luda/luda.py
@@ -72,3 +72,9 @@ def add_display():
     except:
         print "Warning: DISPLAY not passed thru"
         return ""
+
+def parse_tuple(tuple_string):
+    """
+    strip any whitespace then outter characters.
+    """
+    return tuple_string.strip().strip("\"[]")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='luda',
-    version='0.3.1',
+    version='0.3.2',
     description="ludicrously awesome [w]rapper for nvidia-docker",
     long_description=readme + '\n\n' + history,
     author="Ryan Olson",


### PR DESCRIPTION
I havent looked into any of the testing functionality but these new features fixed a bug with the --display option. As well, this allows me to use the existing canned CMD and ENTRYPOINT settings in the Docker file when no arguments are sent to run.

Commit Message:
added new cli flag to prevent the work vol from being mounted. Fixed some issues with spacing between commands. added ability to use existing entrypoints and cmd if no additional arguments are specified