### PR TITLE
Templates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,3 +6,14 @@ History
 ------------------
 
 * First release on PyPI.
+
+0.4.0 (2017-06-01)
+------------------
+
+* Added configurable abbreviations to simply long image names
+* Added templates to extend images from reusable templated Dockerfiles
+* Added entrypoint and command inspection on the base_image to ensure the correct scripts/commands
+  executed on container launch
+* Removed --docker_run_args and replaced with luda managed `--rm`, `-d`, `-t`, `-i` options which map
+  directly to the docker equivalents
+* Improved landing page documentation (still more needs to be done)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ luda intercepts the `-v/--volume` option and provides convenience methods simila
 # --volume data::ro
 ```
 
+#### Home Directory
+
+The user's home directory is a special case which mounts the user's home directory on the host
+to `/home/$USER` in the container.  This option is enabled by default, but can be disabled by
+passing `--no-home` on the commandline.
+
+#### Current Working Directory
+
+luda will map the current working directory from which the `luda` command was executed on the host
+to `/work` in the container and override the container's working directory to `/work`.  This behavior
+can be overridden by passing a volume mount or disabled by passing `None` to to the `--work` option.
+
+Examples:
+```
+# mounts the current working directory on the host to `/my-working-dir`
+# in the container; `/my-working-dir` become the default working directory
+--work .:/my-working-dir
+
+# mounts `~/other-dir` to `/other-dir` in the container; `/other-dir`
+# becomes the default working directory in the container
+--work ~/other-dir
+
+# use the working directory as specified by the container image
+--work None
+--work none
+```
+
 ### Abbreviations
 
 You can set up abbreviations for commonly used URLs by including an `abbreviations` key in the yaml config file. By default,

--- a/README.md
+++ b/README.md
@@ -10,15 +10,62 @@ ludicrously awesome [w]rapper for nvidia-docker
 pip install luda
 ```
 
-Note: On a Mac, you will need to install this somewhere else besides
-`/usr/local/` because of Docker's restrictions on touching the host OS.
+## Quickstart
 
 ```
-cd Projects
-git clone https://github.com/ryanolson/luda.git
-cd luda
-pip install -e .
+luda nvidia/cuda:8.0-devel
 ```
+
+todo: describe what luda is doing with the simpliest of commands
+
+### Volumes
+
+todo: show shortcuts for volume mounting
+
+### Displays
+
+```
+luda --with-display nvidia/cuda:8.0-devel
+```
+
+todo: show opengl containers
+
+### Docker
+
+```
+luda --with-docker nvidia/cuda:8.0-devel
+```
+
+### Templates
+
+Templates provide an easy way to extend container images with pre-defined content.
+Assume I have the following `Dockerfile` defined in `~/.config/luda/templates/dev`.
+
+```
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        vim sudo python-dev python-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install luda
+```
+
+The developer option `--dev` is a special case of `--template dev`.  Running the following commands performs a one-time
+extensions of the `nvidia/cuda:8.0-devel` image with the `Dockerfile` above.  The new images generated will be
+`luda/nvidia-cuda-8.0-devel:dev` or `luda/{{ base_image }}:{{ template }}` where `base_image` has all `/` and `:` replaced
+with `-`.
+
+
+```
+luda --dev nvidia/cuda:8.0-devel
+```
+
+```
+luda --template dev nvidia/cuda:8.0-devel
+```
+
+The first time this command is invoked `luda/nvidia-cuda-8.0-devel:dev` will be created.  Subsequent invocation will
+either update the image if either the base image (`nvidia/cuda:8.0-devel`) or the template directory
+(`~/.config/luda/templates/dev`) has detected changes.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ todo: describe what luda is doing with the simpliest of commands
 
 ### Volumes
 
-todo: show shortcuts for volume mounting
+luda intercepts the `-v/--volume` option and provides convenience methods similar to
+`docker-compose` in that relative paths are supported.  If no
+
+```
+# absolute path readonly
+--volume /path/data:/data:ro
+
+# relative path readonly
+--volume /path/data:/data:ro
+
+# relative path, no internal path --> mount internal at `/{{ basename(hostpath) }}`
+# mounts $PWD/data --> /data inside the container
+# --volume data
+
+# same as above, but readonly
+# --volume data::ro
+```
 
 ### Displays
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ luda intercepts the `-v/--volume` option and provides convenience methods simila
 # --volume data::ro
 ```
 
+### Abbreviations
+
+You can set up abbreviations for commonly used URLs by including an `abbreviations` key in the yaml config file. By default,
+luda includes the `nv:` which expands to `nvcr.io/nvidia/{0}`, where `{0}` is the remainding portion of the image name after
+the abbreviation.
+
+in `config.yml`
+```
+abbreviations:
+  nv: nvcr.io/nvidia/{1}
+```
+
+Usage `nv:tensorflow:17.04` expands to `nvcr.io/nvidia/tensorflow:17.04`:
+```
+luda nv:tensorflow:17.04
+```
+
 ### Displays
 
 ```

--- a/luda/__init__.py
+++ b/luda/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Ryan Olson"""
 __email__ = 'rmolson@gmail.com'
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/luda/__init__.py
+++ b/luda/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Ryan Olson"""
 __email__ = 'rmolson@gmail.com'
-__version__ = '0.3.2'
+__version__ = '0.4.0'

--- a/luda/bootstrap/init.sh
+++ b/luda/bootstrap/init.sh
@@ -17,10 +17,6 @@ useradd --shell /bin/bash -u $USER_ID --gid $GRP_ID -o -c "" --create-home \
   -G sudo,$GRP_NAME $USER_NAME > /dev/null 2>&1
 export HOME=/home/$USER_NAME
 
-if [ -n "$DEVTOOLS" ]; then
-  apt update
-  apt install -y --no-install-recommends sudo
-fi
 echo "$USER_NAME ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 if [ ${#@} -eq 0 ]; then

--- a/luda/cli.py
+++ b/luda/cli.py
@@ -52,6 +52,7 @@ def generate_dockerfile_extension(base_image, template_name):
         tag = "luda/{0}:{1}".format(base_image.replace('/','-').replace(':', '-'), template_name)
         click.echo("Building image: {0} ...".format(tag))
         client.images.build(path=os.getcwd(), tag=tag)
+    return tag
 
 
 # ideas from:
@@ -208,10 +209,13 @@ def main(docker_args, display, docker, dev, rm=None, detach=None, tty=None, stdi
         if curr_cmd:
             docker_args += (curr_cmd,)
 
-    if dev:
-        generate_dockerfile_extension(image_and_args[0], "dev")
+    docker_args = list(docker_args)
 
-    cmd = " ".join(nvargs + list(docker_args))
+    if dev:
+        image = generate_dockerfile_extension(image_and_args[0], "dev")
+        docker_args[0] = image
+
+    cmd = " ".join(nvargs + docker_args)
     click.echo(cmd)
     subprocess.call(cmd, shell=True)
 

--- a/luda/config.py
+++ b/luda/config.py
@@ -2,6 +2,7 @@
 
 """Global configuration handling."""
 
+import collections
 import copy
 import io
 import os
@@ -21,13 +22,22 @@ DEFAULT_CONFIG = {
 }
 
 
+def update(d, u):
+    for k, v in u.iteritems():
+        if isinstance(v, collections.Mapping):
+            r = update(d.get(k, {}), v)
+            d[k] = r
+        else:
+            d[k] = u[k]
+    return d
+
 def read_config():
     config_file = os.path.join(click.get_app_dir(APP_NAME), 'config.yml')
     config_dict = copy.copy(DEFAULT_CONFIG)
     if os.path.exists(config_file):
         with io.open(config_file, encoding='utf-8') as file_handle:
             yaml_dict = poyo.parse_string(file_handle.read())
-        config_dict.update(yaml_dict)
+        update(config_dict, yaml_dict)
     return config_dict
 
 

--- a/luda/config.py
+++ b/luda/config.py
@@ -3,6 +3,7 @@
 """Global configuration handling."""
 
 import copy
+import io
 import os
 
 import click

--- a/luda/config.py
+++ b/luda/config.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""Global configuration handling."""
+
+import copy
+import os
+
+import click
+import poyo
+
+
+APP_NAME = 'luda'
+
+BUILTIN_ABBREVIATIONS = {
+    'nv': 'nvcr.io/nvidia/{0}',
+}
+
+DEFAULT_CONFIG = {
+    'abbreviations': BUILTIN_ABBREVIATIONS,
+}
+
+
+def read_config():
+    config_file = os.path.join(click.get_app_dir(APP_NAME), 'config.yml')
+    config_dict = copy.copy(DEFAULT_CONFIG)
+    if os.path.exists(config_file):
+        with io.open(config_file, encoding='utf-8') as file_handle:
+            yaml_dict = poyo.parse_string(file_handle.read())
+        config_dict.update(yaml_dict)
+    return config_dict
+
+
+def get_template_path(template_name):
+    template_path = os.path.join(click.get_app_dir(APP_NAME), 'templates', template_name)
+    template_file = os.path.join(template_path, "Dockerfile")
+    if not os.path.isdir(template_path):
+        raise ValueError("{0} does not exist. Please create the template directory".format(template_path))
+    if not os.path.isfile(template_file):
+        raise ValueError("{0}: Dockerfile was not found in {1}.".format(template_name, template_path))
+    return template_path

--- a/luda/luda.py
+++ b/luda/luda.py
@@ -83,3 +83,20 @@ def parse_tuple(tuple_string):
     strip any whitespace then outter characters.
     """
     return tuple_string.strip().strip("\"[]")
+
+
+def expand_abbreviations(template, abbreviations):
+    """Expand abbreviations in a template name.
+    :param template: The project template name.
+    :param abbreviations: Abbreviation definitions.
+    """
+    if template in abbreviations:
+        return abbreviations[template]
+
+    # Split on colon. If there is no colon, rest will be empty
+    # and prefix will be the whole template
+    prefix, sep, rest = template.partition(':')
+    if prefix in abbreviations:
+        return abbreviations[prefix].format(rest)
+
+    return template

--- a/luda/utils.py
+++ b/luda/utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import contextlib
+import os
+import shutil
+import tempfile
+
+
+@contextlib.contextmanager
+def cd(newdir, cleanup=lambda: True):
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)
+        cleanup()
+
+
+@contextlib.contextmanager
+def tempdir():
+    dirpath = tempfile.mkdtemp()
+    def cleanup():
+        shutil.rmtree(dirpath)
+    with cd(dirpath, cleanup):
+        yield dirpath

--- a/luda/utils.py
+++ b/luda/utils.py
@@ -13,8 +13,8 @@ def cd(newdir, cleanup=lambda: True):
     try:
         yield
     finally:
-        os.chdir(prevdir)
         cleanup()
+        os.chdir(prevdir)
 
 
 @contextlib.contextmanager

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
 
 setup(
     name='luda',
-    version='0.3.2',
+    version='0.4.0',
     description="ludicrously awesome [w]rapper for nvidia-docker",
     long_description=readme + '\n\n' + history,
     author="Ryan Olson",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ requirements = [
     'Click>=6.0',
     'docker>=2.3.0',
     'j2docker>=0.1.0',
+    'poyo>=0.4.1',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,9 @@ setup(
     packages=[
         'luda',
     ],
-    package_dir={'luda':
-                 'luda'},
+    package_dir={
+        'luda': 'luda',
+    },
     entry_points={
         'console_scripts': [
             'luda=luda.cli:main'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'Click>=6.0',
-    # TODO: put package requirements here
+    'docker>=2.3.0',
+    'j2docker>=0.1.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
Templates provide an easy way to extend container images with pre-defined content. Assume I have the following `Dockerfile` defined in `~/.config/luda/templates/dev`.
```
RUN apt-get update && apt-get install -y --no-install-recommends \
        vim sudo python-dev python-pip && \
    rm -rf /var/lib/apt/lists/*

RUN pip install luda
```

The developer option `--dev` is a special case of `--template dev`. Running the following commands performs a one-time extensions of the `nvidia/cuda:8.0-devel` image with the Dockerfile above. The new images generated will be `luda/nvidia-cuda-8.0-devel:dev` or `luda/{{ base_image }}:{{ template }}` where base_image has all `/` and `:` replaced with `-`.
```
luda --dev nvidia/cuda:8.0-devel
```
```
luda --template dev nvidia/cuda:8.0-devel
```
The first time this command is invoked `luda/nvidia-cuda-8.0-devel:dev` will be created. Subsequent invocation will either update the image if either the base image (`nvidia/cuda:8.0-devel`) or the template directory (`~/.config/luda/templates/dev`) has detected changes.